### PR TITLE
Integrate OPA policy evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # codex-test
-This is a test project to verify codex ability
+
+This project demonstrates an example attribute-based access control (ABAC) system written in Kotlin. Policy evaluation is delegated to [Open Policy Agent](https://www.openpolicyagent.org/) (OPA). The Rego policy can be found in `opa/policy.rego` and uses group permissions defined in `opa/data.json`.
+
+## Building
+
+Use Gradle to build and run the tests:
+
+```bash
+gradle test
+```
+
+The tests illustrate how on-call engineers, leader approval and group permissions affect access decisions. An `opa` CLI must be available on your `PATH` for the tests to evaluate the Rego policy.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    kotlin("jvm") version "2.0.21"
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/opa/data.json
+++ b/opa/data.json
@@ -1,0 +1,5 @@
+{
+  "group_permissions": {
+    "analytics": ["metabase"]
+  }
+}

--- a/opa/policy.rego
+++ b/opa/policy.rego
@@ -1,0 +1,21 @@
+package access
+
+default allow = false
+
+allow {
+    input.user.onCall
+    input.user.domain == input.resource.domain
+}
+
+allow {
+    input.user.domain == "A"
+    input.requested == "read_write"
+    input.user.leaderApproved
+}
+
+allow {
+    some group
+    group := input.user.groups[_]
+    resource := data.group_permissions[group][_]
+    resource == input.resource.name
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "codex-test"

--- a/src/main/kotlin/com/example/abac/AccessControl.kt
+++ b/src/main/kotlin/com/example/abac/AccessControl.kt
@@ -1,0 +1,65 @@
+package com.example.abac
+
+enum class Permission { READ, WRITE, READ_WRITE }
+
+data class User(
+    val name: String,
+    val domain: String,
+    val onCall: Boolean = false,
+    val leaderApproved: Boolean = false,
+    val groups: Set<String> = emptySet()
+)
+
+data class Resource(
+    val name: String,
+    val domain: String
+)
+
+data class AccessRequest(
+    val user: User,
+    val resource: Resource,
+    val requested: Permission
+)
+
+/**
+ * Attribute-based access control system implementing simple policies.
+ */
+class ABACSystem(
+    /**
+     * Mapping from group name to resources the group can access.
+     * The permission granted equals the requested permission.
+     */
+    private val groupPermissions: Map<String, Set<String>> = emptyMap()
+) {
+    /**
+     * Evaluates whether a request should be granted.
+     */
+    fun isAccessAllowed(request: AccessRequest): Boolean {
+        val user = request.user
+        val resource = request.resource
+
+        // Policy 1: On-call engineer can access resources in their own domain.
+        if (user.onCall && user.domain == resource.domain) {
+            return true
+        }
+
+        // Policy 2: Domain A engineers require leader approval for read-write access.
+        if (
+            user.domain == "A" &&
+            request.requested == Permission.READ_WRITE &&
+            user.leaderApproved
+        ) {
+            return true
+        }
+
+        // Policy 3: Group-based permissions.
+        for (group in user.groups) {
+            val allowedResources = groupPermissions[group] ?: continue
+            if (resource.name in allowedResources) {
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/src/main/kotlin/com/example/abac/OpaAccessControl.kt
+++ b/src/main/kotlin/com/example/abac/OpaAccessControl.kt
@@ -1,0 +1,47 @@
+package com.example.abac
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.nio.file.Files
+import kotlin.io.path.createTempFile
+
+/**
+ * Access control system that delegates policy evaluation to OPA.
+ * The class invokes the `opa` CLI to evaluate a Rego policy.
+ */
+class OpaAccessControl(
+    private val policyFile: String,
+    private val dataFile: String? = null
+) {
+    private val mapper = jacksonObjectMapper()
+
+    fun isAccessAllowed(request: AccessRequest): Boolean {
+        val inputFile = createTempFile(prefix = "input", suffix = ".json").toFile()
+        mapper.writeValue(inputFile, request)
+
+        val args = mutableListOf(
+            "opa", "eval", "-f", "json", "-i", inputFile.absolutePath,
+            "-d", policyFile
+        )
+        if (dataFile != null) {
+            args.addAll(listOf("-d", dataFile))
+        }
+        args.add("data.access.allow")
+
+        val process = ProcessBuilder(args)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText()
+        process.waitFor()
+        inputFile.delete()
+
+        val json = mapper.readTree(output)
+        val result = json["result"]
+        if (result != null && result.isArray && result.size() > 0) {
+            val expressions = result[0]["expressions"]
+            if (expressions != null && expressions.isArray && expressions.size() > 0) {
+                return expressions[0]["value"].asBoolean()
+            }
+        }
+        return false
+    }
+}

--- a/src/test/kotlin/com/example/abac/AccessControlTest.kt
+++ b/src/test/kotlin/com/example/abac/AccessControlTest.kt
@@ -1,0 +1,43 @@
+package com.example.abac
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AccessControlTest {
+    @Test
+    fun `oncall engineer gets access to own domain`() {
+        val user = User(name = "alice", domain = "payments", onCall = true)
+        val resource = Resource(name = "payments_db", domain = "payments")
+        val request = AccessRequest(user, resource, Permission.READ_WRITE)
+        val abac = OpaAccessControl("opa/policy.rego", "opa/data.json")
+        assertTrue(abac.isAccessAllowed(request))
+    }
+
+    @Test
+    fun `domain A engineer needs leader approval for RW`() {
+        val user = User(name = "bob", domain = "A", leaderApproved = true)
+        val resource = Resource(name = "domainA_db", domain = "A")
+        val request = AccessRequest(user, resource, Permission.READ_WRITE)
+        val abac = OpaAccessControl("opa/policy.rego", "opa/data.json")
+        assertTrue(abac.isAccessAllowed(request))
+    }
+
+    @Test
+    fun `access granted via group`() {
+        val user = User(name = "carol", domain = "B", groups = setOf("analytics"))
+        val resource = Resource(name = "metabase", domain = "analytics")
+        val request = AccessRequest(user, resource, Permission.READ)
+        val abac = OpaAccessControl("opa/policy.rego", "opa/data.json")
+        assertTrue(abac.isAccessAllowed(request))
+    }
+
+    @Test
+    fun `deny when no policy matches`() {
+        val user = User(name = "dave", domain = "B")
+        val resource = Resource(name = "metabase", domain = "analytics")
+        val request = AccessRequest(user, resource, Permission.READ)
+        val abac = OpaAccessControl("opa/policy.rego", "opa/data.json")
+        assertFalse(abac.isAccessAllowed(request))
+    }
+}


### PR DESCRIPTION
## Summary
- add Rego policy and sample data for OPA
- implement `OpaAccessControl` class that calls the `opa` CLI
- use OPA-based access control in unit tests
- document OPA usage in README and add jackson dependency

## Testing
- `gradle test --no-daemon` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '2.0.21'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8e048f508329bdd49bd15a75fc20